### PR TITLE
Feature: Player ID pages

### DIFF
--- a/client/lib/meteor/router.coffee
+++ b/client/lib/meteor/router.coffee
@@ -8,3 +8,9 @@ Router.route '/people'
 
 Router.route '/nfl/players', {name: 'nflPlayersList'}, ->
 	@render 'nflPlayersList'
+
+Router.route '/nfl/players/:espn_id', {
+  name: 'playerDescriptionImagePage',
+  data: ->
+    NflPlayers.findOne({espn_id: parseInt(@params.espn_id)})
+}

--- a/client/views/nfl_players/nflPlayersList.coffee
+++ b/client/views/nfl_players/nflPlayersList.coffee
@@ -99,14 +99,14 @@ Template.teamDropdown.helpers
     ]
 
 
-Template.playerDescriptionVisual.helpers
+Template.playerDescriptionImage.helpers
 
   # obj is passed in as an argument in the template helper.
   # The two attributes of this object are
   # `espn_id`: the id of the player's url page on espn.com
   # `espn_size` String: the size to fetch from espn's cdn
   #
-  playerImageESPNSrc: (obj) ->
+  playerImageESPN: (obj) ->
 
     if obj.hash.espn_size
       size = switch obj.hash.espn_size

--- a/client/views/nfl_players/nflPlayersList.html
+++ b/client/views/nfl_players/nflPlayersList.html
@@ -12,9 +12,9 @@
   <!-- List -->
   <h4>{{totalNflPlayersCount}} Total</h4>
   <h4>{{nflPositionCount}} Total</h4>
-  <ul>
+  <ul class='nflPlayersList'>
     {{#each nflPlayers}}
-      {{>playerDescriptionVisual}}
+      {{>playerDescriptionImage}}
     {{/each}}
   </ul>
 </template>
@@ -29,11 +29,19 @@
 
 <!--  -->
 <template name="playerDescriptionSimple">
-  <li>{{full_name}} - {{position}} - {{team}} - {{jersey_number}}</li>
+  <li class='nflPlayer'>{{full_name}} - {{position}} - {{team}} - {{jersey_number}}</li>
 </template>
 
-<template name="playerDescriptionVisual">
-  <li><img class='player-img' src={{ playerImageESPNSrc espn_id = this.espn_id espn_size = 'medium'}}>{{full_name}} - {{position}} - {{team}} - {{jersey_number}}</li>
+<template name="playerDescriptionImage">
+  <li class='nflPlayer'>
+    <a href={{pathFor 'playerDescriptionImagePage' }}>
+      <img class='player-img' src={{ playerImageESPN espn_id = this.espn_id espn_size = 'medium'}}>{{full_name}} - {{position}} - {{team}} - {{jersey_number}}
+    </a>
+  </li>
+</template>
+
+<template name="playerDescriptionImagePage">
+{{> playerDescriptionImage}}
 </template>
 
 <template name='teamDropdown'>

--- a/client/views/nfl_players/nflPlayersList.sass
+++ b/client/views/nfl_players/nflPlayersList.sass
@@ -1,0 +1,4 @@
+li.nflPlayer
+  list-style-type: none
+  padding: 0
+  margin: 0


### PR DESCRIPTION
FUNCTIONALITY: 
This adds in individual pages of the type `nfl/players/:espn_id`

From the player list page, a link to link to the individual players page also exists. 
Currently this is a base implementation, as the individual players page template is simply a re-rendering of the list player template. 

STYLE:
-Also removed bullet list styling
TODO: Will add a more fleshed out player id page in the future.
