### PR TITLE
FEATURE: Implement Search Bar Functionality

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -18,4 +18,5 @@ nemo64:bootstrap
 less
 mquandalle:jade
 natestrauser:animate-css
+matteodem:easy-search
 

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -49,11 +49,13 @@ less@1.0.11
 livedata@1.0.11
 localstorage@1.0.1
 logging@1.0.5
+matteodem:easy-search@1.1.5
 meteor-platform@1.2.0
 meteor@1.1.3
 minifiers@1.1.2
 minimongo@1.0.5
 mobile-status-bar@1.0.1
+mongo-livedata@1.0.6
 mongo@1.0.8
 mquandalle:jade@0.2.9
 multiply:iron-router-progress@1.0.0
@@ -77,6 +79,7 @@ sha@1.0.1
 spacebars-compiler@1.0.3
 spacebars@1.0.3
 srp@1.0.1
+standard-app-packages@1.0.3
 stylus@1.0.5
 templating@1.0.9
 tracker@1.0.3

--- a/client/views/nfl_players/nflPlayersList.coffee
+++ b/client/views/nfl_players/nflPlayersList.coffee
@@ -113,4 +113,10 @@ Template.playerCardPhoto.helpers
 
     'http://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/' + obj.hash.espn_id + '.png' + size
 
+Template.nflPlayerSearchResults.helpers
+
+  # potentially should be global helper function
+  searchResultsExist: ->
+    searchInstance = EasySearch.getComponentInstance {index: 'nflPlayersSearch'}
+    return searchInstance.get('total') != 0
 

--- a/client/views/nfl_players/nflPlayersList.html
+++ b/client/views/nfl_players/nflPlayersList.html
@@ -4,12 +4,17 @@
   {{> positionDropdown}}
   {{> teamDropdown}}
 
+  <!-- Search -->
+  {{> nflPlayerSearch}}
+
   <!-- List -->
   <h4>{{totalNflPlayersCount}} Total</h4>
   <h4>{{nflPositionCount}} Total</h4>
   <ul class='nflPlayersList'>
+    {{> nflPlayerSearchResults}}
+
     {{#each nflPlayers}}
-      {{>playerCard}}
+      {{> playerCard}}
     {{/each}}
   </ul>
 </template>
@@ -63,4 +68,22 @@
       <option value={{this}}>{{this}}</option>
     {{/each}}
   </select>
+</template>
+
+<template name="nflPlayerSearch">
+    {{> esInput index="nflPlayersSearch" placeholder="Search Player" class='nflPlayerSearchBar' type='Search'}}
+
+    {{#ifEsHasNoResults index="nflPlayersSearch"}}
+      <span class="searchNoResultsAlert">Whoops. This is not fantasy search.</span>
+    {{/ifEsHasNoResults}}
+</template>
+
+<template name='nflPlayerSearchResults'>
+  {{#esEach index="nflPlayersSearch"}}
+    {{> playerCard}}
+  {{/esEach}}
+
+  {{#if searchResultsExist}}
+    <div class='listDivider'></div>
+  {{/if}}
 </template>

--- a/client/views/nfl_players/nflPlayersList.sass
+++ b/client/views/nfl_players/nflPlayersList.sass
@@ -11,7 +11,7 @@ li.nflPlayer
   .photoCol
     float: left
     width: 300px
-    
+
     img.playerPhoto
       border-radius: 30px
 
@@ -26,6 +26,16 @@ li.nflPlayer
   .cardJerseyNumber
     font-size: 8em
     -webkit-text-stroke: 3px red
-  
+
   .cardPosition
     font-size: 1.5em
+
+  .searchNoResultsAlert
+    font-style: italic
+
+.listDivider
+  border-top: 1px solid #eaeaea
+  clear: both
+  margin: 9px 0 0 0
+  padding: 10px 0 0 0
+  overflow: hidden

--- a/lib/models/init.coffee
+++ b/lib/models/init.coffee
@@ -1,2 +1,16 @@
+# Set Up Collections
 @People = new Mongo.Collection("people")
 @NflPlayers = new Mongo.Collection('nflPlayers')
+
+# EasySearch for Search Indexes
+# To add in other fields to search against, simply add it to the first argument list
+# https://github.com/matteodem/meteor-easy-search/wiki/Getting-started
+# NflPlayers.initEasySearch(['full_name'], {
+#     'limit' : 3
+# })
+
+EasySearch.createSearchIndex('nflPlayersSearch', {
+    'field' : ['full_name'],            # required, searchable field(s)
+    'collection' : NflPlayers,          # required, Mongo Collection
+    'limit' : 3                         # not required, default is 10
+});


### PR DESCRIPTION
This implements a search bar that with meteor-easy-search https://github.com/matteodem/meteor-easy-search/

Displays the card template for the users above the current selection. Easy search allows for a lot of flexibility in terms of template reactivity 
when a search occurs. Search counts, finding out if a user is currently searching or finished are included.

I could not find a way to style the searchbar in the way I wanted to easily, and it also uses a regular text box instead of a search box (so you miss -webkit features like the (x) button in the searchbar. However, this is a good first pass that implements search functionality across the `full_name` attribute of the NflPlayers collection.

-Implements `meteor-easy-search` for searching across Collections in Mongo (ElasticSearch is supported in the future)
-Renders template of search results to the area of the cardlist (above the other filtered selection of cardlist results)
-Small divider between search results and cardlist results
